### PR TITLE
fix: use string instead of boolean in YAML for "YES"

### DIFF
--- a/src/instructlab/sdg/pipelines/full/knowledge.yaml
+++ b/src/instructlab/sdg/pipelines/full/knowledge.yaml
@@ -41,7 +41,7 @@ blocks:
     type: FilterByValueBlock
     config:
       filter_column: judgment
-      filter_value: YES
+      filter_value: "YES"
       operation: eq
     drop_columns:
       - judgment


### PR DESCRIPTION
`field: YES` will be parsed to boolean in YAML, and resulting `"field": True` in Python. This makes any use of "field" as a string problematic in the code. This commit fixes this bug by quoting it properly.